### PR TITLE
[model] Introduce Service + Inject models

### DIFF
--- a/Sources/InjectAnnotation.swift
+++ b/Sources/InjectAnnotation.swift
@@ -1,0 +1,20 @@
+import SourceryRuntime
+import Foundation
+
+struct InjectAnnotation {
+    let scope: String?
+    let name: String?
+    let type: String?
+
+    init(scope: String?, name: String?, type: String?) {
+        self.scope = scope
+        self.name = name
+        self.type = type
+    }
+
+    init(attributes: [String: Any]) {
+        self.init(scope: attributes["scope"] as? String,
+                name: attributes["name"] as? String,
+                type: attributes["type"] as? String)
+    }
+}

--- a/Sources/Service.swift
+++ b/Sources/Service.swift
@@ -1,0 +1,10 @@
+import SourceryRuntime
+
+struct Service {
+    let factory: Method
+    let registerTypeName: String
+    let parameters: [MethodParameter: Any]
+    let scope: String?
+    /// name of the service, if any
+    let name: String?
+}

--- a/Sources/Service.swift
+++ b/Sources/Service.swift
@@ -2,7 +2,7 @@ import SourceryRuntime
 
 struct Service {
     let factory: Method
-    let registerTypeName: String
+    let resolvedTypeName: String
     let parameters: [MethodParameter: Any]
     let scope: String?
     /// name of the service, if any

--- a/Sources/ServiceProvider.swift
+++ b/Sources/ServiceProvider.swift
@@ -2,7 +2,7 @@ import SourceryRuntime
 
 class ServiceProvider {
     /// Find and return all services annotated with `inject` annotation
-    func findInjectedServices() -> [Service] {
+    func findAnnotatedServices() -> [Service] {
         return types.all
         .filter(annotated: "inject")
         .map { service in
@@ -11,7 +11,7 @@ class ServiceProvider {
             let annotation = InjectAnnotation(attributes: service.annotations["inject"] as? [String: Any] ?? [:])
             
             return Service(factory: initializer,
-                            registerTypeName: annotation.type ?? initializer.returnTypeName.name,
+                            resolvedTypeName: annotation.type ?? initializer.returnTypeName.name,
                             parameters: [:],
                             scope: annotation.scope,
                             name: annotation.name)
@@ -27,7 +27,7 @@ class ServiceProvider {
         .filter { method in method.callName == "instantiate" }
         .map {
             Service(factory: $0,
-                    registerTypeName: $0.returnTypeName.name,
+                    resolvedTypeName: $0.returnTypeName.name,
                     parameters: [:],
                     scope: nil,
                     name: nil)

--- a/Sources/ServiceProvider.swift
+++ b/Sources/ServiceProvider.swift
@@ -6,8 +6,9 @@ class ServiceProvider {
         return types.all
         .filter(annotated: "inject")
         .map { service in
-            // FIXME if no initializer is found
-            let initializer = service.initializers.filter(annotated: "inject").first ?? service.initializers.first!
+            guard let initializer = service.initializers.filter(annotated: "inject").first ?? service.initializers.first! else {
+                fatalError("No init method found. You need to declare one.")    
+            }
             let annotation = InjectAnnotation(attributes: service.annotations["inject"] as? [String: Any] ?? [:])
             
             return Service(factory: initializer,

--- a/Sources/ServiceProvider.swift
+++ b/Sources/ServiceProvider.swift
@@ -1,0 +1,36 @@
+import SourceryRuntime
+
+class ServiceProvider {
+    /// Find and return all services annotated with `inject` annotation
+    func findInjectedServices() -> [Service] {
+        return types.all
+        .filter(annotated: "inject")
+        .map { service in
+            // FIXME if no initializer is found
+            let initializer = service.initializers.filter(annotated: "inject").first ?? service.initializers.first!
+            let annotation = InjectAnnotation(attributes: service.annotations["inject"] as? [String: Any] ?? [:])
+            
+            return Service(factory: initializer,
+                            registerTypeName: annotation.type ?? initializer.returnTypeName.name,
+                            parameters: [:],
+                            scope: annotation.scope,
+                            name: annotation.name)
+
+                
+        }
+    }
+
+    func findFactoryServices() -> [Service] {
+        return types.all
+        .filter(annotated: "provider")
+        .flatMap { provider in provider.staticMethods }
+        .filter { method in method.callName == "instantiate" }
+        .map {
+            Service(factory: $0,
+                    registerTypeName: $0.returnTypeName.name,
+                    parameters: [:],
+                    scope: nil,
+                    name: nil)
+        }
+    }
+}

--- a/Sources/Sourcery+AnnotationInject.swift
+++ b/Sources/Sourcery+AnnotationInject.swift
@@ -2,6 +2,12 @@ import SourceryRuntime
 
 extension Array where Element: Annotated {
     func filter(annotated annotation: String) -> [Element] {
-        return filter { $0.annotations[annotation] != nil }
+        return filter { $0.hasAnnotation(annotation) }
+    }
+}
+
+extension Annotated {
+    func hasAnnotation(_ annotation: String) -> Bool {
+        return annotations[annotation] != nil
     }
 }

--- a/Sources/Sourcery+AnnotationInject.swift
+++ b/Sources/Sourcery+AnnotationInject.swift
@@ -1,0 +1,7 @@
+import SourceryRuntime
+
+extension Array where Element: Annotated {
+    func filter(annotated annotation: String) -> [Element] {
+        return filter { $0.annotations[annotation] != nil }
+    }
+}

--- a/Templates/Partials/Annotation.swift
+++ b/Templates/Partials/Annotation.swift
@@ -1,7 +1,0 @@
-<%
-
-func has(_ model: Annotated, annotation: String) -> Bool {
-  return model.annotations[annotation] != nil
-}
-
--%>

--- a/Templates/Partials/Method.swift
+++ b/Templates/Partials/Method.swift
@@ -1,23 +1,12 @@
 <%
 
-func providers() -> [SourceryRuntime.Method] {
-    return types.all
-    .filter { has($0, annotation: "provider") }
-    .flatMap { provider in provider.staticMethods }
-    .filter { method in method.callName == "instantiate" }
-}
-
-func provider(for service: MethodParameter) -> SourceryRuntime.Method? {
-  return providers().first { $0.returnTypeName == service.typeName }
-}
-
 /// - Returns: a String of method parameters with their values.
 /// Params value annotated "provided" is considered to be named as the param itself
 func parametersWithValue(_ method: SourceryRuntime.Method) -> [(label: String, value: String)] {
   var paramsWithValue: [(label: String, value: String)] = []
 
   for param in method.parameters {
-    let value = has(param, annotation: "provided")
+    let value = param.hasAnnotation("provided")
     ? param.name
     : "resolver.registeredService()"
 

--- a/Templates/Partials/Service.swift
+++ b/Templates/Partials/Service.swift
@@ -1,24 +1,7 @@
 <%
 
-func serviceScope(_ service: Type) -> String? {
-  guard let injectAnnotation = service.annotations["inject"] as? [String: String] else {
-    return nil
-  }
-
-  return injectAnnotation["scope"]
-}
-
-func serviceResolvedType(_ service: Type) -> String {
-    guard let annotation = service.annotations["inject"] as? [String: String],
-          let typeName = annotation["type"] else {
-        return service.name
-    }
-
-    return typeName
-}
-
 func attributesAnnotatedInject(_ service: Type) -> ([Variable], [String]) {
-  let annotatedAttributes = service.instanceVariables.filter { has($0, annotation: "inject") }
+  let annotatedAttributes = service.instanceVariables.filter(annotated: "inject")
   var attributes: [Variable] = []
   var errors: [String] = []
 

--- a/Templates/Register.swifttemplate
+++ b/Templates/Register.swifttemplate
@@ -5,31 +5,31 @@ import Swinject
 import <%= `import` %>
 <%_ } -%>
 
-<%- include("Partials/Annotation.swift") -%>
+<%- includeFile("../Sources/InjectAnnotation.swift") -%>
+<%- includeFile("../Sources/Service.swift") -%>
+<%- includeFile("../Sources/Sourcery+AnnotationInject.swift") -%>
+<%- includeFile("../Sources/ServiceProvider.swift") -%>
 <%- include("Partials/Method.swift") -%>
 <%- include("Partials/MethodParameter.swift") -%>
 <%- include("Partials/Service.swift") -%>
 <%- include("Partials/String.swift") -%>
 
 <%_
-  func factory(with method: SourceryRuntime.Method?) -> String {
-    guard let method = method else {
-        return """
-        { _ in
-            #error(\"No init method found.\")
-            }
-        """
+  func factory(with service: Service) -> String {
+    let method = service.factory
+    let parameters = method.parameters.filter(annotated: "provided")
+    let serviceParameters = method.parameters.filter { !parameters.contains($0) }
+    let factories = ServiceProvider().findFactoryServices()
+
+    let nonInjectableParameters = serviceParameters
+    .filter { !$0.hasAnnotation("inject") }
+    .filter { param in
+      let first = factories.first { $0.resolvedTypeName == param.typeName.name }
+      return first == nil ? true : false
     }
 
-    let parameters = method.parameters.filter { has($0, annotation: "provided") }
-    let services = method.parameters.filter { !parameters.contains($0) }
-    let nonInjectableServices = services.filter { service in
-        return service.type.map { !has($0, annotation: "inject") } ?? false
-        && provider(for: service) == nil
-    }
-
-    guard nonInjectableServices.isEmpty else {
-        let errors = nonInjectableServices
+    guard nonInjectableParameters.isEmpty else {
+        let errors = nonInjectableParameters
         .map { "#error(parameter '\($0.name)' requires \($0.typeName) to be annotated `inject` or have a `provider`.)" }
 
         return
@@ -47,8 +47,8 @@ import <%= `import` %>
     """
   }
 
-  func initCompleted(_ service: Type) -> String? {
-    let (attributes, errors) = attributesAnnotatedInject(service)
+  func initCompleted(_ service: Service) -> String? {
+    let (attributes, errors) = attributesAnnotatedInject(service.factory.definedInType!)
     let attributesStr = attributes.map { "service.\($0.name) = resolver.registeredService()" }
     let errorsStr = errors.map { "#error(\"\($0)\")"}
     let afterInit = attributesStr + errorsStr
@@ -64,24 +64,23 @@ import <%= `import` %>
     """
   }
 
-  func serviceOptions(_ service: Type) -> [String?] {
+  func serviceOptions(_ service: Service) -> [String?] {
     return [
         initCompleted(service),
-        serviceScope(service).map { ".inObjectScope(.\($0))" }
+        service.scope.map { ".inObjectScope(.\($0))" }
     ]
   }
 -%>
 
 class AnnotationAssembly: Assembly {
   func assemble(container: Container) {
-  <%_ for service in types.all.filter({ has($0, annotation: "inject") }) { -%>
-    <%_ let initializer = service.initializers.filter { has($0, annotation: "inject") }.first ?? service.initializers.first -%>
-
-    container.register(<%= service.name %>.self, factory: <%= factory(with: initializer) -%>)
+  <%_ for service in ServiceProvider().findAnnotatedServices() { -%>
+    container.register(<%= service.factory.returnTypeName %>.self, factory: <%= factory(with: service) -%>)
     <%= serviceOptions(service).compactMap { $0 }.joined(separator: "\n") _%>
   <%_ } -%>
 
-  <%_ for method in providers() { -%>
+  <%_ for service in ServiceProvider().findFactoryServices() { -%>
+    <%_ let method = service.factory -%>
     container.register(<%= method.returnTypeName %>.self, factory: <%= method.definedInTypeName?.name ?? "" %>.<%= method.selectorName %>)
   <%_ } -%>
   }

--- a/Templates/ServiceResolver.swifttemplate
+++ b/Templates/ServiceResolver.swifttemplate
@@ -5,7 +5,10 @@ import Swinject
 import <%= `import` %>
 <%_ } -%>
 
-<%- include("Partials/Annotation.swift") -%>
+<%- includeFile("../Sources/InjectAnnotation.swift") -%>
+<%- includeFile("../Sources/Service.swift") -%>
+<%- includeFile("../Sources/Sourcery+AnnotationInject.swift") -%>
+<%- includeFile("../Sources/ServiceProvider.swift") -%>
 <%- include("Partials/Method.swift") -%>
 <%- include("Partials/MethodParameter.swift") -%>
 <%- include("Partials/Service.swift") -%>
@@ -15,23 +18,21 @@ typealias ServiceResolver = Resolver
 
 /// Defines methods to *safely* access injected dependencies
 extension ServiceResolver {
-<%_ for service in types.all.filter({ has($0, annotation: "inject") }) { -%>
-    <%_ guard let factory = service.initializers.filter({ has($0, annotation: "inject") }).first ?? service.initializers.first else { -%>
-        #error("No init method found.")
-        <%_ exit(1) -%>
-    <%_ } -%>
-    <%_ let parameters = factory.parameters.filter { has($0, annotation: "provided") } -%>
+<%_ for service in ServiceProvider().findAnnotatedServices() { -%>
+    <%_ let method = service.factory -%>
+    <%_ let parameters = method.parameters.filter(annotated: "provided") -%>
 
-    func registeredService(<%= stringify(parameters: parameters, printing: .definition) %>) -> <%= serviceResolvedType(service) %> {
-        return resolve(<%= service.name %>.self<%= prefixNonEmpty(concatParamNames(of: parameters), with: ", arguments: ") %>)!
+    func registeredService(<%= stringify(parameters: parameters, printing: .definition) %>) -> <%= service.resolvedTypeName %> {
+        return resolve(<%= method.returnTypeName %>.self<%= prefixNonEmpty(concatParamNames(of: parameters), with: ", arguments: ") %>)!
     }
 <%_ } -%>
 
-<%_ for factory in providers() { -%>
-    <%_ let parameters = factory.parameters.filter { has($0, annotation: "provided") } -%>
+<%_ for service in ServiceProvider().findFactoryServices() { -%>
+    <%_ let method = service.factory -%>
+    <%_ let parameters = method.parameters.filter(annotated: "provided") -%>
 
-    func registeredService(<%= stringify(parameters: parameters, printing: .definition) %>) -> <%= factory.returnTypeName %> {
-        return resolve(<%= factory.returnTypeName %>.self<%= prefixNonEmpty(concatParamNames(of: parameters), with: ", arguments: ") %>)!
+    func registeredService(<%= stringify(parameters: parameters, printing: .definition) %>) -> <%= service.resolvedTypeName %> {
+        return resolve(<%= method.returnTypeName %>.self<%= prefixNonEmpty(concatParamNames(of: parameters), with: ", arguments: ") %>)!
     }
 <%_ } -%>
 }


### PR DESCRIPTION
Introduced two models:
- InjectAnnotation
- Service

and migrated new templates to use them. Turns out Sourcery has a way to include Swift source code into templates, so no need to wrap them into <% %> tags.

It should help to introduce tests on the long term.